### PR TITLE
fix : Calibrate Sensor button does not crash the application now.

### DIFF
--- a/sandbox/sensor/calibration_sensor.py
+++ b/sandbox/sensor/calibration_sensor.py
@@ -4,6 +4,7 @@ pn.extension()
 from sandbox.sensor import Sensor
 from sandbox.projector import Projector
 from sandbox import _calibration_dir
+from sandbox.main_thread import MainThread
 
 import matplotlib.pyplot as plt
 import matplotlib as mpl
@@ -12,7 +13,7 @@ from matplotlib.figure import Figure
 
 class CalibSensor:  # TODO: include automatic
     """Module to calibrate the sensor"""
-    def __init__(self,  calibprojector: str = None, name: str = 'kinectv2', **kwargs):
+    def __init__(self,  calibprojector: str = None, name: str = 'kinectv2', main_thread:MainThread = None, **kwargs):
         # color map setup
         self.c_under = '#DBD053'
         self.c_over = '#DB3A34'
@@ -20,7 +21,11 @@ class CalibSensor:  # TODO: include automatic
         self.c_margin = '#084C61'
         self.margin_alpha = 0.5
         self.calibprojector = calibprojector
-        self.sensor = Sensor(name=name, invert=False, clip_values=False, gauss_filter=False, **kwargs)
+        if main_thread == None :
+            self.sensor = Sensor(name=name, invert=False, clip_values=False, gauss_filter=False, **kwargs)
+        else :
+            self.sensor = main_thread.sensor
+        self.main_thread = main_thread
         self.projector = Projector(calibprojector=self.calibprojector, **kwargs)
         import copy
         self.cmap = copy.copy(mpl.cm.get_cmap("Greys_r"))
@@ -117,12 +122,14 @@ class CalibSensor:  # TODO: include automatic
                          self._widget_json_filename,
                          self._widget_json_save
                          )
+        exit = pn.Column(self._widget_exit_calib)
 
         rows = pn.Row(widgets, self.calib_notebook_frame)
         panel = pn.Column('## Sensor calibration', rows)
         tabs = pn.Tabs(('Calibration', panel),
                        ("Box dimensions", box),
-                       ("Save files", save)
+                       ("Save files", save),
+                       ("Exit",exit)
                        )
         return tabs
 
@@ -223,6 +230,10 @@ class CalibSensor:  # TODO: include automatic
         self._widget_json_load_projector = pn.widgets.Button(name='Load calibration')
         self._widget_json_load_projector.param.watch(self._callback_json_load_projector, 'clicks', onlychanged=False)
 
+        self._widget_exit_calib = pn.widgets.Button(name='Exit Calibration')
+        self._widget_exit_calib.param.watch(self._callback_exit, 'clicks', onlychanged=False)
+
+
         return True
 
         # sensor callbacks
@@ -280,6 +291,10 @@ class CalibSensor:  # TODO: include automatic
 
     def _callback_box_height(self, event):
         self.sensor.box_height = float(event.new)
+
+    def _callback_exit(self,event):
+        self.main_thread.sensor.param_for_main_thread()
+        self.main_thread.resume()
 
     # TODO: Make sense to enable this automatic calibration?
     """def _callback_enable_auto_calibration(self, event):

--- a/sandbox/sensor/sensor_api.py
+++ b/sandbox/sensor/sensor_api.py
@@ -247,6 +247,16 @@ class Sensor:
             frame = self.get_inverted_frame(frame)
         self.depth = frame
         return self.depth
+    
+    def param_for_calib_sensor(self):
+        self.filter = False
+        self.clip = False
+        self.invert = False
+
+    def param_for_main_thread(self):
+        self.filter = True
+        self.clip = True
+        self.invert = True
 
     @property
     def vmax(self):

--- a/sandbox_server.py
+++ b/sandbox_server.py
@@ -5,23 +5,13 @@ from sandbox import _calibration_dir
 _calibprojector = _calibration_dir + "my_projector_calibration.json"
 _calibsensor = _calibration_dir + "my_sensor_calibration.json"
 
-from sandbox.projector import Projector
-from sandbox.sensor import Sensor
-from sandbox.markers import MarkerDetection
-
-projector = Projector(calibprojector=_calibprojector, use_panel=True)
-sensor = Sensor(calibsensor=_calibsensor, name="kinect_v2")
-aruco = MarkerDetection(sensor=sensor)
-
-external_modules = dict(gempy_module=True,
-                        gimli_module=True,
-                        torch_module=True,
-                        devito_module=True)
+external_modules = dict(gempy_module=False,
+                        gimli_module=False,
+                        torch_module=False,
+                        devito_module=False)
 
 from sandbox.sandbox_api import Sandbox
-module = Sandbox(sensor=sensor,
-                 projector=projector,
-                 aruco=aruco,
+module = Sandbox(aruco=False,
                  kwargs_external_modules=external_modules)
 
 main_widget = module.show_widgets()


### PR DESCRIPTION
Sensor and Projector initialised one time and modified after to feat their uses. In that way, when loading the sensor's calibration mudole, it does not crash. When finishedn clicking "exit" resume the main tread with the changes.